### PR TITLE
Don't kill implicit if stop failed.

### DIFF
--- a/pkg/hyperkit/driver.go
+++ b/pkg/hyperkit/driver.go
@@ -349,7 +349,8 @@ func (d *Driver) Stop() error {
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("hyperkit sigterm failed"))
 		}
-		for i := 0; i < 5; i++ {
+		// wait 120s for graceful shutdown
+		for i := 0; i < 60; i++ {
 			time.Sleep(2 * time.Second)
 			s, _ := d.GetState()
 			log.Debugf("VM state: %s", s)

--- a/pkg/hyperkit/driver.go
+++ b/pkg/hyperkit/driver.go
@@ -338,26 +338,28 @@ func (d *Driver) Stop() error {
 	if err := d.verifyRootPermissions(); err != nil {
 		return err
 	}
-	err := d.sendSignal(syscall.SIGTERM)
+
+	s, err := d.GetState()
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("hyperkit sigterm failed"))
+		return err
 	}
 
-	// wait 5s for graceful shutdown
-	for i := 0; i < 5; i++ {
-		log.Debug("waiting for graceful shutdown")
-		time.Sleep(time.Second * 1)
-		s, err := d.GetState()
+	if s != state.Stopped {
+		err := d.sendSignal(syscall.SIGTERM)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("hyperkit waiting graceful shutdown failed"))
+			return errors.Wrap(err, fmt.Sprintf("hyperkit sigterm failed"))
 		}
-		if s == state.Stopped {
-			return nil
+		for i := 0; i < 5; i++ {
+			time.Sleep(2 * time.Second)
+			s, _ := d.GetState()
+			log.Debugf("VM state: %s", s)
+			if s == state.Stopped {
+				return nil
+			}
 		}
+		return errors.New("VM Failed to gracefully shutdown, try the kill command")
 	}
-
-	log.Debug("sending sigkill")
-	return d.Kill()
+	return nil
 }
 
 // InvalidPortNumberError implements the Error interface.


### PR DESCRIPTION
Stop is use for graceful shutdown and
it shouldn't call implicit kill function
if shutdown doesn't happen but return an error.

Current shutdown waiting period is 5 sec which is
way to less in term of shuting down coreos VM, so
this is increased to 120 sec.