### PR TITLE
Don't wait for VM to stop in case of delete

### DIFF
--- a/pkg/hyperkit/driver.go
+++ b/pkg/hyperkit/driver.go
@@ -169,7 +169,7 @@ func (d *Driver) Remove() error {
 		log.Debugf("Error checking machine status: %v, assuming it has been removed already", err)
 	}
 	if s == state.Running {
-		if err := d.Stop(); err != nil {
+		if err := d.Kill(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
`Remove ()` function should not call `Stop ()`
and wait till stop return since stop do graceful
shutdown of the VM which we don't need in case of
remove, otherwise `delete` operation will be waiting
more than 1-2 mins which is not acceptable.