### PR TITLE
 Remove driver binary installation step from build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,3 @@ build: $(BUILD_DIR) vendor
 			-installsuffix "static" \
 			-o $(BUILD_DIR)/crc-driver-hyperkit
 	chmod +x $(BUILD_DIR)/crc-driver-hyperkit
-	sudo mv $(BUILD_DIR)/crc-driver-hyperkit /usr/local/bin/ && sudo chown root:wheel /usr/local/bin/crc-driver-hyperkit && sudo chmod u+s /usr/local/bin/crc-driver-hyperkit

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BUILD_DIR ?= out
 ORG := github.com/machine-drivers
 REPOPATH ?= $(ORG)/docker-machine-driver-hyperkit
 
+default: build
 vendor:
 	go mod vendor
 


### PR DESCRIPTION
We don't need to have installation step in the build target
since we are not even using this location for testing purpose
any more.