### PR TITLE
Sync the machine code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/code-ready/machine-driver-hyperkit
 
 require (
-	github.com/code-ready/machine v0.0.0-20190821063716-34d5b6049a38
+	github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b
 	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936
 	github.com/moby/hyperkit v0.0.0-20171204115932-858492e3d919
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -6,9 +6,13 @@ github.com/code-ready/machine v0.0.0-20190731093717-b6d974ad44d0 h1:036aGx7BK4a7
 github.com/code-ready/machine v0.0.0-20190731093717-b6d974ad44d0/go.mod h1:2Kr23hBx5xUHetynE+4hFBwn7Xkx5qoF0SY1FzmLz74=
 github.com/code-ready/machine v0.0.0-20190821063716-34d5b6049a38 h1:aWtngqG5thaPezD/qobOkxrhOx0+fe9FgRBFlcsweyw=
 github.com/code-ready/machine v0.0.0-20190821063716-34d5b6049a38/go.mod h1:2Kr23hBx5xUHetynE+4hFBwn7Xkx5qoF0SY1FzmLz74=
+github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b h1:uDsea77LGyGm5kDFi4N8xyi2k06dlCKvK09or3BGsUA=
+github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b/go.mod h1:x/y5No186t4X+Z9fQafLByNoo+K4MyNzxgcKKq76N+U=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95 h1:S4qyfL2sEm5Budr4KVMyEniCy+PbS55651I/a+Kn/NQ=
+github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95/go.mod h1:QiyDdbZLaJ/mZP4Zwc9g2QsfaEA4o7XvvgZegSci5/E=
 github.com/intel-go/cpuid v0.0.0-20181003105527-1a4a6f06a1c6/go.mod h1:RmeVYf9XrPRbRc3XIx0gLYA8qOFvNoPOfaEZduRlEp4=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936 h1:kw1v0NlnN+GZcU8Ma8CLF2Zzgjfx95gs3/GN3vYAPpo=
@@ -32,4 +36,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190529164535-6a60838ec259 h1:so6Hr/LodwSZ5UQDu/7PmQiDeS112WwtLvU3lpSPZTU=
+golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This sync is needed to fetch `driver.GetBundleName()` to check bundle
information of a running/stopped instance.