### PR TITLE
Use hyperkit Driver definition from machine module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
 module github.com/code-ready/machine-driver-hyperkit
 
+go 1.13
+
 require (
-	github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b
+	github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4
 	github.com/mitchellh/go-ps v0.0.0-20170309133038-4fdf99ab2936
 	github.com/moby/hyperkit v0.0.0-20171204115932-858492e3d919
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/code-ready/machine v0.0.0-20190821063716-34d5b6049a38 h1:aWtngqG5thaP
 github.com/code-ready/machine v0.0.0-20190821063716-34d5b6049a38/go.mod h1:2Kr23hBx5xUHetynE+4hFBwn7Xkx5qoF0SY1FzmLz74=
 github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b h1:uDsea77LGyGm5kDFi4N8xyi2k06dlCKvK09or3BGsUA=
 github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b/go.mod h1:x/y5No186t4X+Z9fQafLByNoo+K4MyNzxgcKKq76N+U=
+github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4 h1:7rvtC0pR4q6UXWpywkvpYhHpIk5b5g27al2wLynx7sI=
+github.com/code-ready/machine v0.0.0-20200810103403-d2277fb226c4/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/pkg/hyperkit/driver.go
+++ b/pkg/hyperkit/driver.go
@@ -29,6 +29,7 @@ import (
 	"syscall"
 	"time"
 
+	hyperkitdriver "github.com/code-ready/machine/drivers/hyperkit"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/log"
 	"github.com/code-ready/machine/libmachine/mcnflag"
@@ -48,30 +49,19 @@ const (
 		"sudo chown root:wheel %s && sudo chmod u+s %s"
 )
 
-// Driver is the machine driver for Hyperkit
-type Driver struct {
-	*drivers.BaseDriver
-	DiskPathURL    string
-	CPU            int
-	Memory         int
-	Cmdline        string // kernel commandline
-	UUID           string
-	VpnKitSock     string
-	VSockPorts     []string
-	VmlinuzPath    string
-	InitrdPath     string
-	SSHKeyPath     string
-	HyperKitPath   string
-}
+type Driver hyperkitdriver.Driver
 
 // NewDriver creates a new driver for a host
 func NewDriver() *Driver {
 	return &Driver{
-		BaseDriver: &drivers.BaseDriver{
-			SSHUser: DefaultSSHUser,
+		VMDriver: &drivers.VMDriver{
+
+			BaseDriver: &drivers.BaseDriver{
+				SSHUser: DefaultSSHUser,
+			},
+			CPU:    DefaultCPUs,
+			Memory: DefaultMemory,
 		},
-		CPU:    DefaultCPUs,
-		Memory: DefaultMemory,
 	}
 }
 


### PR DESCRIPTION
This ensures crc and the hyperkit machine driver uses the same
definition for this struct.