### PR TITLE
Move copy code where it is used

### DIFF
--- a/pkg/hyperkit/copy.go
+++ b/pkg/hyperkit/copy.go
@@ -1,0 +1,33 @@
+package hyperkit
+
+import (
+	"io"
+	"os"
+)
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	defer out.Close()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, fi.Mode())
+}

--- a/pkg/hyperkit/copy_test.go
+++ b/pkg/hyperkit/copy_test.go
@@ -1,0 +1,53 @@
+package hyperkit
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyFile(t *testing.T) {
+	testStr := "test-machine"
+
+	srcFile, err := ioutil.TempFile("", "machine-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srcFi, err := srcFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _ = srcFile.Write([]byte(testStr))
+	srcFile.Close()
+
+	srcFilePath := filepath.Join(os.TempDir(), srcFi.Name())
+
+	destFile, err := ioutil.TempFile("", "machine-copy-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destFi, err := destFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	destFile.Close()
+
+	destFilePath := filepath.Join(os.TempDir(), destFi.Name())
+
+	if err := copyFile(srcFilePath, destFilePath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadFile(destFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != testStr {
+		t.Fatalf("expected data \"%s\"; received \"%s\"", testStr, string(data))
+	}
+}

--- a/pkg/hyperkit/driver.go
+++ b/pkg/hyperkit/driver.go
@@ -32,7 +32,6 @@ import (
 	hyperkitdriver "github.com/code-ready/machine/drivers/hyperkit"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/log"
-	"github.com/code-ready/machine/libmachine/mcnutils"
 	"github.com/code-ready/machine/libmachine/state"
 	ps "github.com/mitchellh/go-ps"
 	hyperkit "github.com/moby/hyperkit/go"
@@ -54,8 +53,8 @@ func NewDriver() *Driver {
 	return &Driver{
 		VMDriver: &drivers.VMDriver{
 			BaseDriver: &drivers.BaseDriver{},
-			CPU:    DefaultCPUs,
-			Memory: DefaultMemory,
+			CPU:        DefaultCPUs,
+			Memory:     DefaultMemory,
 		},
 	}
 }
@@ -92,7 +91,7 @@ func (d *Driver) Create() error {
 		return err
 	}
 
-	if err := mcnutils.CopyFile(d.ImageSourcePath, d.getDiskPath()); err != nil {
+	if err := copyFile(d.ImageSourcePath, d.getDiskPath()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There is no need to share this kind of code in a global library.
It's better to have duplication than depending too much on machine code.