### PR TITLE
Use same hyperkit qcow2 parameters as before

### DIFF
--- a/pkg/hyperkit/driver.go
+++ b/pkg/hyperkit/driver.go
@@ -58,6 +58,10 @@ func (qcow *QcowDisk) Ensure() error {
 	return nil
 }
 
+func (qcow *QcowDisk) AsArgument() string {
+	return fmt.Sprintf("virtio-blk,file://%s,format=qcow", qcow.Path)
+}
+
 // NewDriver creates a new driver for a host
 func NewDriver() *Driver {
 	return &Driver{


### PR DESCRIPTION
With the update of the hyperkit go module, the hyperkit commandline
for qcow2 disks changed and became more complicated:
-s 2:0,virtio-blk,file:///Users/crcqe/.crc/machines/crc/crc.qcow2?sync=&buffered=1,format=qcow,qcow-config=discard=true;compact_after_unmaps=0;keep_erased=0;runtime_asserts=false

Before it was simpler:
-s 2:0,virtio-blk,file:///Users/teuf/.crc/machines/crc/crc.qcow2,format=qcow

We've been hitting disk related failures during our testing of the
machine driver, so let's switch back to the same qcow2 options as before
this go module update. Hopefully this will help.