### PR TITLE
Download the golangci-lint to $GOPATH/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 # Go and compilation related variables
 BUILD_DIR ?= out
+GOPATH ?= $(shell go env GOPATH)
 
 ORG := github.com/machine-drivers
 REPOPATH ?= $(ORG)/docker-machine-driver-hyperkit
+GOLANGCI_LINT_VERSION=v1.39.0
 
 default: build
 
@@ -27,9 +29,15 @@ build: $(BUILD_DIR) vendor lint test
 			-o $(BUILD_DIR)/crc-driver-hyperkit
 	chmod +x $(BUILD_DIR)/crc-driver-hyperkit
 
+.PHONY: golangci-lint
+golangci-lint:
+	@if $(GOPATH)/bin/golangci-lint version 2>&1 | grep -vq $(GOLANGCI_LINT_VERSION); then\
+		pushd /tmp && GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) && popd; \
+	fi
+
 .PHONY: lint
-lint:
-	golangci-lint run
+lint: golangci-lint
+	$(GOPATH)/bin/golangci-lint run
 
 .PHONY: test
 test:


### PR DESCRIPTION
As of now if golangci-lint not available in the path then `make`
execution fails. This patch will try to fetch golangci-lint to
$GOPATH/bin